### PR TITLE
fix(compile):due to the ant-design-pro's problem, we need to remove it

### DIFF
--- a/.webpackrc
+++ b/.webpackrc
@@ -1,7 +1,6 @@
 {
   "entry": "app/assets/index.js",
   "extraBabelPlugins": [
-    "transform-decorators-legacy",
     ["import", { "libraryName": "antd", "libraryDirectory": "es", "style": true }]
   ],
   "env": {


### PR DESCRIPTION
https://github.com/eggjs/egg/issues/2540

以下为说明：

这个问题ant-design-pro 已经解决了

ant-design/ant-design-pro#1345

egg-ant-design-pro里，需要在.webpackrc中删掉"transform-decorators-legacy"这个配置，在项目编译过程中，才不会报上面那个错

所以，建议在项目里去除这个配置，对使用本项目的人来说或许更友好

