### PR TITLE
chore: 完善post代理请求，如login的参数传递

### DIFF
--- a/app/controller/home.js
+++ b/app/controller/home.js
@@ -15,8 +15,9 @@ class HomeController extends Controller {
     let params = {
       method: this.ctx.method,
       dataType: 'json'
-    }
-    if (this.ctx.method) {
+    };
+    let method = params.method.toLowerCase();
+    if (method === 'put' || method === 'post') {
       params.data = ctx.request.body
     }
     const res = await this.ctx.curl(url, params);

--- a/app/controller/home.js
+++ b/app/controller/home.js
@@ -12,9 +12,15 @@ class HomeController extends Controller {
     // use roadhog mock api first
     const url = 'http://127.0.0.1:8000' + ctx.path + '?' + ctx.querystring;
 
-    const res = await this.ctx.curl(url, {
+    let params = {
       method: this.ctx.method,
-    });
+      dataType: 'json'
+    }
+    if (this.ctx.method) {
+      params.data = ctx.request.body
+    }
+    const res = await this.ctx.curl(url, params);
+    
     ctx.body = res.data;
     ctx.status = res.status;
   }


### PR DESCRIPTION
问题描述：如果在7001端口打开页面，localhost:7001，则进入登陆页，并且点击登录只会进入这段逻辑
```
res.send({
      status: 'error',
      type,
      currentAuthority: 'guest'
});
```
原因是因为egg在代理请求的时候并没有传入post的body参数