### PR TITLE
fix ✖  error     Error: Cannot find module 'eslint-config-prettier/@typescript-eslint'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ sudo: false
 language: node_js
 node_js:
   - '8'
+before_install:
+  - npm i npminstall -g
 install:
-  - npm i npminstall && npminstall
+  - npminstall
 script:
   - npm run ci
 after_script:

--- a/app/web/src/components/PageHeaderWrapper/index.js
+++ b/app/web/src/components/PageHeaderWrapper/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { FormattedMessage } from 'umi/locale';
 import Link from 'umi/link';
-import PageHeader from '@/components/PageHeader';
 import { connect } from 'dva';
+import PageHeader from '@/components/PageHeader';
 import GridContent from './GridContent';
 import styles from './index.less';
 import MenuContext from '@/layouts/MenuContext';

--- a/app/web/src/pages/Authorized.js
+++ b/app/web/src/pages/Authorized.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import Redirect from 'umi/redirect';
 import RenderAuthorized from '@/components/Authorized';
 import { getAuthority } from '@/utils/authority';
-import Redirect from 'umi/redirect';
 
 const Authority = getAuthority();
 const Authorized = RenderAuthorized(Authority);

--- a/app/web/src/pages/Dashboard/Analysis.js
+++ b/app/web/src/pages/Dashboard/Analysis.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'dva';
 import { formatMessage, FormattedMessage } from 'umi/locale';
+import numeral from 'numeral';
 import {
   Row,
   Col,
@@ -14,6 +15,7 @@ import {
   Menu,
   Dropdown,
 } from 'antd';
+import NumberInfo from '@/components/NumberInfo';
 import {
   ChartCard,
   MiniArea,
@@ -25,8 +27,6 @@ import {
   TimelineChart,
 } from '@/components/Charts';
 import Trend from '@/components/Trend';
-import NumberInfo from '@/components/NumberInfo';
-import numeral from 'numeral';
 import GridContent from '@/components/PageHeaderWrapper/GridContent';
 import Yuan from '@/utils/Yuan';
 import { getTimeDistance } from '@/utils/utils';

--- a/app/web/src/pages/Dashboard/Monitor.js
+++ b/app/web/src/pages/Dashboard/Monitor.js
@@ -2,11 +2,11 @@ import React, { PureComponent } from 'react';
 import { connect } from 'dva';
 import { formatMessage, FormattedMessage } from 'umi/locale';
 import { Row, Col, Card, Tooltip } from 'antd';
+import numeral from 'numeral';
 import { Pie, WaterWave, Gauge, TagCloud } from '@/components/Charts';
 import NumberInfo from '@/components/NumberInfo';
 import CountDown from '@/components/CountDown';
 import ActiveChart from '@/components/ActiveChart';
-import numeral from 'numeral';
 import GridContent from '@/components/PageHeaderWrapper/GridContent';
 
 import Authorized from '@/utils/Authorized';

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^4.18.2",
     "eslint-config-airbnb": "^17.0.0",
     "eslint-config-egg": "^7.0.0",
-    "eslint-config-prettier": "^3.0.1",
+    "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-compat": "^2.6.2",
     "eslint-plugin-import": "^2.8.0",


### PR DESCRIPTION
目前克隆 egg-ant-design-pro 到本地后
```
npm i 
npm run dev
```
跑不起来：

![image](https://user-images.githubusercontent.com/3367820/61765988-df90da00-ae11-11e9-8253-b8d5f86d37bb.png)


把 eslint-config-prettier 升级到最新版后可以解决。